### PR TITLE
Remove app name from German localization file

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-	<string name="app_name">BetterUntis</string>
-
 	<string name="all_success">Erfolg</string>
 	<string name="all_failed">fehlgeschlagen</string>
 	<string name="all_personal">Persönlich</string>


### PR DESCRIPTION
The name will default to the one from the generic file,
and having it in the German file makes it harder to have a release and
debug version installed simultaneously, since it takes precedence over
the debug name (BetaUntis)